### PR TITLE
feat: add API-level pagination to getValidators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 >
 > **Disclaimer:** Guardian SDK is unaudited, experimental software provided AS-IS. See [SECURITY.md](./SECURITY.md) and [README.md](./README.md) for full disclaimer.
 
+## [Unreleased] — next major (`2.0.0`)
+
+### Breaking Changes
+
+**`@guardian-sdk/bsc`**
+
+- `getValidators(chain, params?)` now returns `ValidatorsPage` instead of `Validator[]`. Destructure with `const { data, pagination } = await sdk.getValidators(chain)`.
+- `GetValidatorsParams.status` removed. Filter validators client-side with `filterByStatus(page.data, status)` exported from `@guardian-sdk/bsc`.
+- Validator `id` changed from a `"<moniker>_<index>"` string to the stable `operatorAddress`. Any code keying validators by `id` across pages must be updated.
+
+### Features
+
+**`@guardian-sdk/bsc`**
+
+- `getValidators` now accepts `{ page, pageSize }` params for server-side pagination against the BNB Chain API. Default page size is 100.
+- `getValidators` returns a `ValidatorsPage` with a `pagination` object (`page`, `pageSize`, `total`, `totalPages`, `hasNextPage`).
+- Input validation: `getValidators` throws `ValidationError` with code `INVALID_PAGE` or `INVALID_PAGE_SIZE` for out-of-range values.
+- Two typed caches replace the single untyped cache in `createStakingService`: one for the full validator list (used by `getDelegations`), one for paginated pages (used by `getValidators`).
+
+**`@guardian-sdk/sdk`**
+
+- `GetValidatorsParams`, `ValidatorsPage`, `ValidatorsPagination`, `validatePageParams`, and `filterByStatus` are now exported from the core SDK for reuse across chain implementations.
+- `ValidationErrorCode` extended with `"INVALID_PAGE"` and `"INVALID_PAGE_SIZE"`.
+
+---
+
 ## [1.0.2](https://github.com/JaimeToca/guardian-stake-sdk/compare/v1.0.1...v1.0.2) (2026-04-08)
 
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The same API surface will be available on every supported chain. Pass the chain 
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| [`getValidators(chain, params?)`](#getvalidatorschain) | `ValidatorsPage` | Paginated validators, optionally filtered by status |
+| [`getValidators(chain, params?)`](#getvalidatorschain) | `ValidatorsPage` | Paginated validators |
 | [`getDelegations(chain, address)`](#getdelegationschain-address) | `Delegations` | All delegations for an address plus a protocol-level summary if available |
 | [`getBalances(chain, address)`](#getbalanceschain-address) | `Balance[]` | Available, staked, pending, and claimable balances |
 | [`getNonce(chain, address)`](#getnoncechain-address) | `number` | Current transaction nonce, required before signing |
@@ -146,7 +146,7 @@ The same API surface will be available on every supported chain. Pass the chain 
 
 ### `getValidators(chain)`
 
-Returns a paginated page of validators. Use `params.page` / `params.pageSize` to navigate pages (1-based, default 20 per page). Use `params.status` to filter by validator status.
+Returns a paginated page of validators. Use `params.page` / `params.pageSize` to navigate pages (1-based, default 100 per page). To filter by status client-side, use `filterByStatus(page.data, status)` from the SDK after fetching.
 
 **Returns:** `Promise<ValidatorsPage>`
 
@@ -156,7 +156,7 @@ interface ValidatorsPage {
   pagination: {
     page: number;
     pageSize: number;
-    total: number;       // total validators on the network (unfiltered)
+    total: number;       // total validators on the network
     totalPages: number;
     hasNextPage: boolean;
   };
@@ -178,18 +178,16 @@ type ValidatorStatus = "Active" | "Inactive" | "Jailed";
 ```
 
 ```typescript
-// First page (default: 20 per page)
+// First page (default: 100 per page)
 const { data: validators, pagination } = await sdk.getValidators(chains.bscMainnet);
 console.log(pagination.total, pagination.hasNextPage);
 
 // Explicit page + size
 const page2 = await sdk.getValidators(chains.bscMainnet, { page: 2, pageSize: 10 });
 
-// Only active validators on page 1
-const active = await sdk.getValidators(chains.bscMainnet, { status: "Active" });
-
-// Active and jailed
-const subset = await sdk.getValidators(chains.bscMainnet, { status: ["Active", "Jailed"] });
+// Filter by status client-side
+import { filterByStatus } from "@guardian-sdk/bsc";
+const active = filterByStatus(validators, "Active");
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The same API surface will be available on every supported chain. Pass the chain 
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| [`getValidators(chain, status?)`](#getvalidatorschain) | `Validator[]` | All validators, optionally filtered by status |
+| [`getValidators(chain, params?)`](#getvalidatorschain) | `ValidatorsPage` | Paginated validators, optionally filtered by status |
 | [`getDelegations(chain, address)`](#getdelegationschain-address) | `Delegations` | All delegations for an address plus a protocol-level summary if available |
 | [`getBalances(chain, address)`](#getbalanceschain-address) | `Balance[]` | Available, staked, pending, and claimable balances |
 | [`getNonce(chain, address)`](#getnoncechain-address) | `number` | Current transaction nonce, required before signing |
@@ -146,11 +146,22 @@ The same API surface will be available on every supported chain. Pass the chain 
 
 ### `getValidators(chain)`
 
-Returns all validators on the network. Pass an optional status filter to narrow the result.
+Returns a paginated page of validators. Use `params.page` / `params.pageSize` to navigate pages (1-based, default 20 per page). Use `params.status` to filter by validator status.
 
-**Returns:** `Promise<Validator[]>`
+**Returns:** `Promise<ValidatorsPage>`
 
 ```typescript
+interface ValidatorsPage {
+  data: Validator[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;       // total validators on the network (unfiltered)
+    totalPages: number;
+    hasNextPage: boolean;
+  };
+}
+
 interface Validator {
   id: string;
   name: string;
@@ -167,14 +178,18 @@ type ValidatorStatus = "Active" | "Inactive" | "Jailed";
 ```
 
 ```typescript
-// All validators
-const validators = await sdk.getValidators(chains.bscMainnet);
+// First page (default: 20 per page)
+const { data: validators, pagination } = await sdk.getValidators(chains.bscMainnet);
+console.log(pagination.total, pagination.hasNextPage);
 
-// Only active validators
-const active = await sdk.getValidators(chains.bscMainnet, "Active");
+// Explicit page + size
+const page2 = await sdk.getValidators(chains.bscMainnet, { page: 2, pageSize: 10 });
+
+// Only active validators on page 1
+const active = await sdk.getValidators(chains.bscMainnet, { status: "Active" });
 
 // Active and jailed
-const subset = await sdk.getValidators(chains.bscMainnet, ["Active", "Jailed"]);
+const subset = await sdk.getValidators(chains.bscMainnet, { status: ["Active", "Jailed"] });
 ```
 
 ---
@@ -389,7 +404,7 @@ import { parseEther } from "viem";
 
 const sdk = new GuardianSDK([bsc({ rpcUrl: "https://bsc-dataseed.bnbchain.org" })]);
 
-const validators = await sdk.getValidators(chains.bscMainnet);
+const { data: validators } = await sdk.getValidators(chains.bscMainnet);
 const fee = await sdk.estimateFee({
   type: "Delegate",
   chain: chains.bscMainnet,
@@ -503,14 +518,17 @@ describe("my staking feature", () => {
   it("renders the validator with the highest APY", async () => {
     const sdk = new GuardianSDK([
       createMockService({
-        getValidators: vi.fn().mockResolvedValue([
-          mockValidator({ name: "Alpha", apy: 8 }),
-          mockValidator({ name: "Beta",  apy: 12 }),
-        ]),
+        getValidators: vi.fn().mockResolvedValue({
+          data: [
+            mockValidator({ name: "Alpha", apy: 8 }),
+            mockValidator({ name: "Beta",  apy: 12 }),
+          ],
+          pagination: { page: 1, pageSize: 20, total: 2, totalPages: 1, hasNextPage: false },
+        }),
       }),
     ]);
 
-    const validators = await sdk.getValidators(chains.bscMainnet);
+    const { data: validators } = await sdk.getValidators(chains.bscMainnet);
     const best = validators.sort((a, b) => b.apy - a.apy)[0];
 
     expect(best.name).toBe("Beta");

--- a/docs/adding-a-chain.md
+++ b/docs/adding-a-chain.md
@@ -183,12 +183,12 @@ Every chain package must implement **five service contracts** from `@guardian-sd
 
 ```typescript
 interface StakingServiceContract {
-  getValidators(): Promise<Validator[]>;
+  getValidators(params?: GetValidatorsParams): Promise<ValidatorsPage>;
   getDelegations(address: string): Promise<Delegations>;
 }
 ```
 
-- `getValidators()` — return ALL validators (active, inactive, jailed). Cache results using `createInMemoryCache` from `@guardian-sdk/sdk`.
+- `getValidators(params?)` — return a paginated page of validators. Fetch from the chain API using `params.page` / `params.pageSize` (converted to `limit` / `offset`). Cache each page separately. Apply `params.status` filtering client-side.
 - `getDelegations(address)` — return active delegations + pending/claimable unbonds + a `StakingSummary` (protocol-level stats: total staked, max APY, min stake amount, unbond period, etc.).
 - Validator shape: `{ id, name, status, description, image, apy, delegators, operatorAddress, creditAddress }`.
 - Use `"Active" | "Inactive" | "Jailed"` for `ValidatorStatus` and `"Active" | "Pending" | "Claimable"` for `DelegationStatus`.
@@ -267,7 +267,7 @@ export function <chain>(config: { rpcUrl: string; logger?: Logger }): GuardianSe
 
   return {
     getChainInfo: () => <chainName>Mainnet,
-    getValidators: (status) => staking.getValidators(status),
+    getValidators: (params) => staking.getValidators(params),
     getDelegations: (address) => staking.getDelegations(address),
     getBalances: (address) => balance.getBalances(address),
     getNonce: (address) => getNonce(/* client */, address),
@@ -500,8 +500,8 @@ const sdk = new GuardianSDK([
 ]);
 
 // Validators
-const validators = await sdk.getValidators(chains.<chainName>Mainnet);
-console.log("validators", validators.length);
+const { data: validators, pagination } = await sdk.getValidators(chains.<chainName>Mainnet);
+console.log("validators", validators.length, "total", pagination.total);
 
 // Delegations
 const ADDRESS = "<your-address>";

--- a/docs/adding-a-chain.md
+++ b/docs/adding-a-chain.md
@@ -188,7 +188,7 @@ interface StakingServiceContract {
 }
 ```
 
-- `getValidators(params?)` — return a paginated page of validators. Fetch from the chain API using `params.page` / `params.pageSize` (converted to `limit` / `offset`). Cache each page separately. Apply `params.status` filtering client-side.
+- `getValidators(params?)` — return a paginated page of validators. Fetch from the chain API using `params.page` / `params.pageSize` (converted to `limit` / `offset`). Cache each page separately. Status filtering is the caller's responsibility — expose `filterByStatus` from the SDK for client-side use.
 - `getDelegations(address)` — return active delegations + pending/claimable unbonds + a `StakingSummary` (protocol-level stats: total staked, max APY, min stake amount, unbond period, etc.).
 - Validator shape: `{ id, name, status, description, image, apy, delegators, operatorAddress, creditAddress }`.
 - Use `"Active" | "Inactive" | "Jailed"` for `ValidatorStatus` and `"Active" | "Pending" | "Claimable"` for `DelegationStatus`.

--- a/docs/adding-a-chain.md
+++ b/docs/adding-a-chain.md
@@ -188,7 +188,7 @@ interface StakingServiceContract {
 }
 ```
 
-- `getValidators(params?)` — return a paginated page of validators. Fetch from the chain API using `params.page` / `params.pageSize` (converted to `limit` / `offset`). Cache each page separately. Status filtering is the caller's responsibility — expose `filterByStatus` from the SDK for client-side use.
+- `getValidators(params?)` — return a paginated page of validators. `GetValidatorsParams` only accepts `page` and `pageSize` — there is no `status` field. Fetch from the chain API using those two params (convert to `limit` / `offset` if the API uses that convention). Cache each page separately. Consumers who want to filter by status call `filterByStatus(page.data, status)` themselves — it is already exported by every chain package via `export * from "@guardian-sdk/sdk"`, so no extra wiring is needed.
 - `getDelegations(address)` — return active delegations + pending/claimable unbonds + a `StakingSummary` (protocol-level stats: total staked, max APY, min stake amount, unbond period, etc.).
 - Validator shape: `{ id, name, status, description, image, apy, delegators, operatorAddress, creditAddress }`.
 - Use `"Active" | "Inactive" | "Jailed"` for `ValidatorStatus` and `"Active" | "Pending" | "Claimable"` for `DelegationStatus`.

--- a/examples/bnb-native-staking-sample.ts
+++ b/examples/bnb-native-staking-sample.ts
@@ -30,9 +30,26 @@ async function sample_check_delegations() {
   const balances = await sdk.getBalances(bscMainnet, "0x166b6b8BFD51655cEA080Cc2C42fcB858645d29b");
   console.log("Balances:", balances);
 
-  // Fetch validators
-  const validators = await sdk.getValidators(bscMainnet);
-  console.log("Validators:", validators);
+  // Fetch validators — first page, 20 per page by default
+  const validatorsPage = await sdk.getValidators(bscMainnet);
+  console.log("Validators:", validatorsPage.data);
+  console.log("Pagination:", validatorsPage.pagination);
+
+  // Fetch a specific page with a custom page size
+  const page2 = await sdk.getValidators(bscMainnet, { page: 2, pageSize: 10 });
+  console.log("Page 2 validators:", page2.data);
+
+  // Filter by status
+  const activeValidators = await sdk.getValidators(bscMainnet, { status: "Active" });
+  console.log("Active validators:", activeValidators.data);
+
+  // Combine pagination and status filter
+  const activePage2 = await sdk.getValidators(bscMainnet, {
+    page: 2,
+    pageSize: 10,
+    status: ["Active", "Inactive"],
+  });
+  console.log("Active + Inactive validators (page 2):", activePage2.data);
 
   // Fetch delegations for an address
   const delegations = await sdk.getDelegations(
@@ -66,7 +83,7 @@ async function sample_delegate_transaction() {
   console.log("Balances:", balances);
 
   // Pick a validator — use getValidators() to browse the full set
-  const validators = await sdk.getValidators(bscMainnet);
+  const { data: validators } = await sdk.getValidators(bscMainnet);
   const validator = validators.find((v) => v.name === "Binance Staking") ?? validators[0];
   console.log(`Delegating to: ${validator.name} (${validator.operatorAddress})`);
 
@@ -113,7 +130,7 @@ async function sample_redelegate_transaction() {
   const AMOUNT = parseUnits("1.01", 18); // 1.01 BNB
   
   // Pick a validator — use getValidators() to browse the full set
-  const validators = await sdk.getValidators(bscMainnet);
+  const { data: validators } = await sdk.getValidators(bscMainnet);
 
   // From Validator A to Validator B
   const fromValidator = validators.find((v) => v.name === "Binance Staking") ?? validators[0];
@@ -165,7 +182,7 @@ async function sample_undelegate_transaction() {
   const AMOUNT = parseUnits("1.01", 18); // 1.01 BNB
 
   // Pick a validator — use getValidators() to browse the full set
-  const validators = await sdk.getValidators(bscMainnet);
+  const { data: validators } = await sdk.getValidators(bscMainnet);
 
   const validator = validators.find((v) => v.name === "Ankr Staking") ?? validators[0];
   console.log(`Undelegating from: ${validator.name} (${validator.operatorAddress})`);

--- a/examples/bnb-native-staking-sample.ts
+++ b/examples/bnb-native-staking-sample.ts
@@ -30,7 +30,7 @@ async function sample_check_delegations() {
   const balances = await sdk.getBalances(bscMainnet, "0x166b6b8BFD51655cEA080Cc2C42fcB858645d29b");
   console.log("Balances:", balances);
 
-  // Fetch validators — first page, 20 per page by default
+  // Fetch validators — first page, default page size
   const validatorsPage = await sdk.getValidators(bscMainnet);
   console.log("Validators:", validatorsPage.data);
   console.log("Pagination:", validatorsPage.pagination);
@@ -38,18 +38,6 @@ async function sample_check_delegations() {
   // Fetch a specific page with a custom page size
   const page2 = await sdk.getValidators(bscMainnet, { page: 2, pageSize: 10 });
   console.log("Page 2 validators:", page2.data);
-
-  // Filter by status
-  const activeValidators = await sdk.getValidators(bscMainnet, { status: "Active" });
-  console.log("Active validators:", activeValidators.data);
-
-  // Combine pagination and status filter
-  const activePage2 = await sdk.getValidators(bscMainnet, {
-    page: 2,
-    pageSize: 10,
-    status: ["Active", "Inactive"],
-  });
-  console.log("Active + Inactive validators (page 2):", activePage2.data);
 
   // Fetch delegations for an address
   const delegations = await sdk.getDelegations(

--- a/packages/bsc/README.md
+++ b/packages/bsc/README.md
@@ -63,7 +63,7 @@ The validator set has grown beyond the original 45-slot design. As of early 2026
 - **Candidates** — occasional block producers, fill slots above position 21
 - **Inactive / Jailed** — registered on-chain but not producing blocks
 
-`getValidators()` returns a paginated page of validators — active, inactive, and jailed. Use `params.page` / `params.pageSize` to navigate pages (default: 20 per page). Pass `params.status` to filter by status.
+`getValidators()` returns a paginated page of validators — active, inactive, and jailed. Use `params.page` / `params.pageSize` to navigate pages (default: 100 per page). To filter by status client-side, use `filterByStatus(page.data, status)` after fetching.
 
 Elections run daily after 00:00 UTC. Each validator sets a **commission rate** — the percentage of block rewards they keep before distributing the rest to delegators. The full validator metadata available on-chain includes moniker, identity, website, details, consensus address, vote address, commission rate, and election info — the SDK surfaces the subset most relevant to delegation UIs.
 
@@ -259,21 +259,19 @@ console.log(`Transaction hash: ${txHash}`);
 
 ### `getValidators`
 
-Returns a paginated page of validators registered on the protocol — active, inactive, and jailed. Pass optional `params` to navigate pages or filter by status.
+Returns a paginated page of validators registered on the protocol — active, inactive, and jailed. Pass optional `params` to navigate pages. To filter by status client-side, use `filterByStatus(page.data, status)` after fetching.
 
 ```typescript
-// First page (default: 20 per page)
+// First page (default: 100 per page)
 const { data: validators, pagination } = await sdk.getValidators(chains.bscMainnet);
 console.log(pagination.total, pagination.hasNextPage);
 
 // Explicit page + size
 const page2 = await sdk.getValidators(chains.bscMainnet, { page: 2, pageSize: 10 });
 
-// Only active validators
-const active = await sdk.getValidators(chains.bscMainnet, { status: "Active" });
-
-// Active and jailed
-const subset = await sdk.getValidators(chains.bscMainnet, { status: ["Active", "Jailed"] });
+// Filter by status client-side
+import { filterByStatus } from "@guardian-sdk/bsc";
+const active = filterByStatus(validators, "Active");
 ```
 
 **Returns:** `Promise<ValidatorsPage>`
@@ -284,7 +282,7 @@ interface ValidatorsPage {
   pagination: {
     page: number;
     pageSize: number;
-    total: number;       // total validators on the network (unfiltered)
+    total: number;       // total validators on the network
     totalPages: number;
     hasNextPage: boolean;
   };

--- a/packages/bsc/README.md
+++ b/packages/bsc/README.md
@@ -63,7 +63,7 @@ The validator set has grown beyond the original 45-slot design. As of early 2026
 - **Candidates** — occasional block producers, fill slots above position 21
 - **Inactive / Jailed** — registered on-chain but not producing blocks
 
-`getValidators()` returns all registered validators — active, inactive, and jailed. Pass an optional status (or array of statuses) to filter: `getValidators(bscMainnet, "Active")`.
+`getValidators()` returns a paginated page of validators — active, inactive, and jailed. Use `params.page` / `params.pageSize` to navigate pages (default: 20 per page). Pass `params.status` to filter by status.
 
 Elections run daily after 00:00 UTC. Each validator sets a **commission rate** — the percentage of block rewards they keep before distributing the rest to delegators. The full validator metadata available on-chain includes moniker, identity, website, details, consensus address, vote address, commission rate, and election info — the SDK surfaces the subset most relevant to delegation UIs.
 
@@ -203,9 +203,9 @@ const sdk = new GuardianSDK([
 
 const ADDRESS = "0xYourAddress";
 
-// 1. Fetch all validators
-const validators = await sdk.getValidators(chains.bscMainnet);
-console.log(`${validators.length} validators found`);
+// 1. Fetch validators (page 1, 20 per page by default)
+const { data: validators, pagination } = await sdk.getValidators(chains.bscMainnet);
+console.log(`${validators.length} validators on this page, ${pagination.total} total`);
 
 // 2. Fetch delegations for an address
 const { delegations, stakingSummary } = await sdk.getDelegations(chains.bscMainnet, ADDRESS);
@@ -259,22 +259,37 @@ console.log(`Transaction hash: ${txHash}`);
 
 ### `getValidators`
 
-Returns all validators registered on the protocol — active, inactive, and jailed. Pass an optional status filter to narrow the result.
+Returns a paginated page of validators registered on the protocol — active, inactive, and jailed. Pass optional `params` to navigate pages or filter by status.
 
 ```typescript
-// All validators
-const validators = await sdk.getValidators(chains.bscMainnet);
+// First page (default: 20 per page)
+const { data: validators, pagination } = await sdk.getValidators(chains.bscMainnet);
+console.log(pagination.total, pagination.hasNextPage);
+
+// Explicit page + size
+const page2 = await sdk.getValidators(chains.bscMainnet, { page: 2, pageSize: 10 });
 
 // Only active validators
-const active = await sdk.getValidators(chains.bscMainnet, "Active");
+const active = await sdk.getValidators(chains.bscMainnet, { status: "Active" });
 
 // Active and jailed
-const subset = await sdk.getValidators(chains.bscMainnet, ["Active", "Jailed"]);
+const subset = await sdk.getValidators(chains.bscMainnet, { status: ["Active", "Jailed"] });
 ```
 
-**Returns:** `Promise<Validator[]>`
+**Returns:** `Promise<ValidatorsPage>`
 
 ```typescript
+interface ValidatorsPage {
+  data: Validator[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;       // total validators on the network (unfiltered)
+    totalPages: number;
+    hasNextPage: boolean;
+  };
+}
+
 interface Validator {
   id: string;                  // Unique identifier
   status: ValidatorStatus;     // Active | Inactive | Jailed
@@ -290,7 +305,7 @@ interface Validator {
 type ValidatorStatus = "Active" | "Inactive" | "Jailed";
 ```
 
-> **Caching:** Validator data is cached in memory for the lifetime of the SDK instance. Validators are a slowly-changing set — elections run once per day at most — so cache invalidation is rarely needed in practice.
+> **Caching:** Each page is cached in memory separately. Validators are a slowly-changing set — elections run once per day at most — so cache invalidation is rarely needed in practice.
 
 > **On-chain data not surfaced here:** The `StakeHub` contract exposes additional per-validator data via `getValidatorCommission`, `getValidatorDescription`, `getValidatorRewardRecord`, `getValidatorElectionInfo`, and `getValidatorConsensusAddress`. These are available for direct RPC calls if your application needs them.
 

--- a/packages/bsc/README.md
+++ b/packages/bsc/README.md
@@ -644,6 +644,8 @@ import { ValidationError } from "@guardian-sdk/bsc";
 | `INVALID_NONCE` | The `nonce` passed to `sign`, `preHash`, or `compile` is negative or not an integer |
 | `INVALID_FEE` | The `fee.gasLimit` or `fee.gasPrice` passed to `sign`, `preHash`, or `compile` is zero or negative |
 | `INVALID_PRIVATE_KEY` | The private key passed to `sign()` is not valid hex, is zero, or exceeds the secp256k1 curve order |
+| `INVALID_PAGE` | The `page` passed to `getValidators` is less than 1 or not an integer |
+| `INVALID_PAGE_SIZE` | The `pageSize` passed to `getValidators` is less than 1 or not an integer |
 
 ---
 

--- a/packages/bsc/src/smartchain/index.ts
+++ b/packages/bsc/src/smartchain/index.ts
@@ -1,5 +1,5 @@
 import { createPublicClient, http } from "viem";
-import type { GuardianServiceContract, Validator, Logger } from "@guardian-sdk/sdk";
+import type { GuardianServiceContract, Logger } from "@guardian-sdk/sdk";
 import { createInMemoryCache, NoopLogger, validateRpcUrl } from "@guardian-sdk/sdk";
 import { bscMainnet, getViemChain } from "../chain";
 import { createStakingRpcClient } from "./rpc/staking-rpc-client";
@@ -38,7 +38,7 @@ export function bsc(config: { rpcUrl: string; logger?: Logger }): GuardianServic
   const stakingRpc = createStakingRpcClient(client, logger);
   const bnbRpc = createBnbRpcClient(logger);
   const staking = createStakingService(
-    createInMemoryCache<string, Validator[]>(),
+    createInMemoryCache<string, unknown>(),
     stakingRpc,
     bnbRpc,
     logger
@@ -49,7 +49,7 @@ export function bsc(config: { rpcUrl: string; logger?: Logger }): GuardianServic
 
   return {
     getChainInfo: () => bscMainnet,
-    getValidators: (status) => staking.getValidators(status),
+    getValidators: (params) => staking.getValidators(params),
     getDelegations: (address) => staking.getDelegations(address),
     getBalances: (address) => balance.getBalances(address),
     getNonce: (address) => getNonce(client, address),

--- a/packages/bsc/src/smartchain/index.ts
+++ b/packages/bsc/src/smartchain/index.ts
@@ -1,5 +1,5 @@
 import { createPublicClient, http } from "viem";
-import type { GuardianServiceContract, Logger } from "@guardian-sdk/sdk";
+import type { GuardianServiceContract, Logger, Validator, ValidatorsPage } from "@guardian-sdk/sdk";
 import { createInMemoryCache, NoopLogger, validateRpcUrl } from "@guardian-sdk/sdk";
 import { bscMainnet, getViemChain } from "../chain";
 import { createStakingRpcClient } from "./rpc/staking-rpc-client";
@@ -38,7 +38,8 @@ export function bsc(config: { rpcUrl: string; logger?: Logger }): GuardianServic
   const stakingRpc = createStakingRpcClient(client, logger);
   const bnbRpc = createBnbRpcClient(logger);
   const staking = createStakingService(
-    createInMemoryCache<string, unknown>(),
+    createInMemoryCache<string, Validator[]>(),
+    createInMemoryCache<string, ValidatorsPage>(),
     stakingRpc,
     bnbRpc,
     logger

--- a/packages/bsc/src/smartchain/rpc/bnb-rpc-client-contract.ts
+++ b/packages/bsc/src/smartchain/rpc/bnb-rpc-client-contract.ts
@@ -1,6 +1,9 @@
 import type { BNBChainValidator, BNBStakingSummary } from "./bnb-rpc-types";
 
 export interface BNBRpcClientContract {
-  getValidators(): Promise<BNBChainValidator[]>;
+  getValidators(params: { page: number; pageSize: number }): Promise<{
+    validators: BNBChainValidator[];
+    total: number;
+  }>;
   getStakingSummary(): Promise<BNBStakingSummary>;
 }

--- a/packages/bsc/src/smartchain/rpc/bnb-rpc-client.ts
+++ b/packages/bsc/src/smartchain/rpc/bnb-rpc-client.ts
@@ -12,23 +12,30 @@ const BASE_MAINNET_URL = "https://api.bnbchain.org/bnb-staking/v1";
 
 export function createBnbRpcClient(logger: Logger = new NoopLogger()): BNBRpcClientContract {
   return {
-    async getValidators(): Promise<BNBChainValidator[]> {
+    async getValidators({
+      page,
+      pageSize,
+    }: {
+      page: number;
+      pageSize: number;
+    }): Promise<{ validators: BNBChainValidator[]; total: number }> {
+      const offset = (page - 1) * pageSize;
       const url = `${BASE_MAINNET_URL}/validator/all`;
-      logger.debug("BNBRpcClient: fetching validators", { url });
+      logger.debug("BNBRpcClient: fetching validators", { url, page, pageSize, offset });
       const start = Date.now();
 
       const response = await fetchOrError<BNBValidatorsResponse>({
         url,
         method: "GET",
-        params: { limit: "100", offset: "0" },
+        params: { limit: String(pageSize), offset: String(offset) },
       });
 
       logger.debug("BNBRpcClient: validators fetched", {
         count: response.data.validators.length,
+        total: response.data.total,
         ms: Date.now() - start,
-        response: response.data,
       });
-      return response.data.validators;
+      return { validators: response.data.validators, total: response.data.total };
     },
 
     async getStakingSummary(): Promise<BNBStakingSummary> {

--- a/packages/bsc/src/smartchain/services/staking-service.ts
+++ b/packages/bsc/src/smartchain/services/staking-service.ts
@@ -13,7 +13,7 @@ import type {
   ValidatorStatus,
   ValidatorsPage,
 } from "@guardian-sdk/sdk";
-import { filterByStatus, ValidationError } from "@guardian-sdk/sdk";
+import { validatePageParams } from "@guardian-sdk/sdk";
 import { parseEvmAddress } from "../validations";
 
 const UNBOUND_PERIOD = 604800000; // 7 days in millis
@@ -44,7 +44,7 @@ function mapValidators(
   logger: Logger
 ): Validator[] {
   return bnbValidators
-    .map((bnbValidator, index) => {
+    .map((bnbValidator) => {
       const operatorAddress = parseEvmAddress(bnbValidator.operatorAddress);
       const creditAddress = contractValidators.get(operatorAddress);
       if (!creditAddress) {
@@ -55,7 +55,7 @@ function mapValidators(
         return undefined;
       }
       return {
-        id: `${bnbValidator.moniker}_${index}`,
+        id: operatorAddress,
         status: getValidatorStatus(bnbValidator),
         name: bnbValidator.moniker,
         description: bnbValidator.miningStatus,
@@ -176,29 +176,21 @@ export function createStakingService(
       const page = params.page ?? 1;
       const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
 
-      if (!Number.isInteger(page) || page < 1)
-        throw new ValidationError("INVALID_PAGE", "page must be an integer of 1 or greater");
-      if (!Number.isInteger(pageSize) || pageSize < 1)
-        throw new ValidationError(
-          "INVALID_PAGE_SIZE",
-          "pageSize must be an integer of 1 or greater"
-        );
+      validatePageParams(params);
 
       const cacheKey = validatorPageCacheKey(page, pageSize);
-
       const cached = pageCache.get(cacheKey);
+
       if (cached) {
         logger.debug("StakingService: validator page cache hit", { page, pageSize });
-        return {
-          ...cached,
-          data: filterByStatus(cached.data, params.status),
-        };
+        return cached;
       }
 
       logger.debug("StakingService: validator page cache miss — fetching from RPC", {
         page,
         pageSize,
       });
+
       const [{ validators: bnbValidators, total }, contractValidators] = await Promise.all([
         bnbRpcClient.getValidators({ page, pageSize }),
         stakingRpcClient.getCreditContractValidators(),
@@ -218,10 +210,7 @@ export function createStakingService(
 
       pageCache.set(cacheKey, result);
       logger.debug("StakingService: validator page cached", { page, pageSize, total });
-      return {
-        ...result,
-        data: filterByStatus(data, params.status),
-      };
+      return result;
     },
 
     async getDelegations(address: string): Promise<Delegations> {

--- a/packages/bsc/src/smartchain/services/staking-service.ts
+++ b/packages/bsc/src/smartchain/services/staking-service.ts
@@ -7,17 +7,20 @@ import { processSingleMulticallResult } from "../abi";
 import type {
   Delegation,
   Delegations,
+  GetValidatorsParams,
   StakingServiceContract,
   Validator,
   ValidatorStatus,
+  ValidatorsPage,
 } from "@guardian-sdk/sdk";
-import { filterByStatus } from "@guardian-sdk/sdk";
+import { filterByStatus, ValidationError } from "@guardian-sdk/sdk";
 import { parseEvmAddress } from "../validations";
 
 const UNBOUND_PERIOD = 604800000; // 7 days in millis
 const REDELEGATION_FEE = 0.002;
 const MIN_AMOUNT_TO_STAKE = parseEther("1.0");
-const VALIDATOR_CACHE_KEY = "bsc-validators";
+const VALIDATOR_ALL_CACHE_KEY = "bsc-validators-all";
+const DEFAULT_PAGE_SIZE = 100;
 const BASE_VALIDATOR_IMAGE_URL =
   "https://raw.githubusercontent.com/bnb-chain/bsc-validator-directory/main/mainnet/validators/";
 
@@ -31,53 +34,64 @@ function getValidatorImage(address: Address): string {
   return `${BASE_VALIDATOR_IMAGE_URL}${address}/logo.png`;
 }
 
-// BSC does not have more than 60 validators — no pagination needed
+function validatorPageCacheKey(page: number, pageSize: number): string {
+  return `bsc-validators-${page}-${pageSize}`;
+}
+
+function mapValidators(
+  bnbValidators: BNBChainValidator[],
+  contractValidators: Map<Address, Address>,
+  logger: Logger
+): Validator[] {
+  return bnbValidators
+    .map((bnbValidator, index) => {
+      const operatorAddress = parseEvmAddress(bnbValidator.operatorAddress);
+      const creditAddress = contractValidators.get(operatorAddress);
+      if (!creditAddress) {
+        logger.warn("StakingService: validator has no credit address — skipping", {
+          moniker: bnbValidator.moniker,
+          operatorAddress,
+        });
+        return undefined;
+      }
+      return {
+        id: `${bnbValidator.moniker}_${index}`,
+        status: getValidatorStatus(bnbValidator),
+        name: bnbValidator.moniker,
+        description: bnbValidator.miningStatus,
+        image: getValidatorImage(operatorAddress),
+        apy: (bnbValidator.apy ?? 0) * 100,
+        delegators: bnbValidator.delegatorCount,
+        operatorAddress,
+        creditAddress: parseEvmAddress(creditAddress),
+      };
+    })
+    .filter((v): v is NonNullable<typeof v> => v !== undefined);
+}
+
 export function createStakingService(
-  cache: CacheContract<string, Validator[]>,
+  cache: CacheContract<string, unknown>,
   stakingRpcClient: StakingRpcClientContract,
   bnbRpcClient: BNBRpcClientContract,
   logger: Logger = new NoopLogger()
 ): StakingServiceContract {
+  // BSC has ~50–60 validators — fetching all in one shot is intentional and cheap.
   async function fetchAllValidators(): Promise<Validator[]> {
-    const cached = cache.get(VALIDATOR_CACHE_KEY);
+    const cached = cache.get(VALIDATOR_ALL_CACHE_KEY) as Validator[] | undefined;
     if (cached) {
-      logger.debug("StakingService: validators cache hit", { count: cached.length });
+      logger.debug("StakingService: all-validators cache hit", { count: cached.length });
       return cached;
     }
 
-    logger.debug("StakingService: validators cache miss — fetching from RPC");
-    const [bnbValidators, contractValidators] = await Promise.all([
-      bnbRpcClient.getValidators(),
+    logger.debug("StakingService: all-validators cache miss — fetching from RPC");
+    const [{ validators: bnbValidators }, contractValidators] = await Promise.all([
+      bnbRpcClient.getValidators({ page: 1, pageSize: 100 }), // intentionally large page size to get all validators in one request
       stakingRpcClient.getCreditContractValidators(),
     ]);
 
-    const validators = bnbValidators
-      .map((bnbValidator, index) => {
-        const operatorAddress = parseEvmAddress(bnbValidator.operatorAddress);
-        const creditAddress = contractValidators.get(operatorAddress);
-        if (!creditAddress) {
-          logger.warn("StakingService: validator has no credit address — skipping", {
-            moniker: bnbValidator.moniker,
-            operatorAddress,
-          });
-          return undefined;
-        }
-        return {
-          id: `${bnbValidator.moniker}_${index}`,
-          status: getValidatorStatus(bnbValidator),
-          name: bnbValidator.moniker,
-          description: bnbValidator.miningStatus,
-          image: getValidatorImage(operatorAddress),
-          apy: (bnbValidator.apy ?? 0) * 100,
-          delegators: bnbValidator.delegatorCount,
-          operatorAddress,
-          creditAddress: parseEvmAddress(creditAddress),
-        };
-      })
-      .filter((v): v is NonNullable<typeof v> => v !== undefined);
-
-    cache.set(VALIDATOR_CACHE_KEY, validators);
-    logger.debug("StakingService: validators cached", { count: validators.length });
+    const validators = mapValidators(bnbValidators, contractValidators, logger);
+    cache.set(VALIDATOR_ALL_CACHE_KEY, validators);
+    logger.debug("StakingService: all-validators cached", { count: validators.length });
     return validators;
   }
 
@@ -157,8 +171,56 @@ export function createStakingService(
   }
 
   return {
-    async getValidators(status?: ValidatorStatus | ValidatorStatus[]): Promise<Validator[]> {
-      return filterByStatus(await fetchAllValidators(), status);
+    async getValidators(params: GetValidatorsParams = {}): Promise<ValidatorsPage> {
+      const page = params.page ?? 1;
+      const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+
+      if (!Number.isInteger(page) || page < 1)
+        throw new ValidationError("INVALID_PAGE", "page must be an integer of 1 or greater");
+      if (!Number.isInteger(pageSize) || pageSize < 1)
+        throw new ValidationError(
+          "INVALID_PAGE_SIZE",
+          "pageSize must be an integer of 1 or greater"
+        );
+
+      const cacheKey = validatorPageCacheKey(page, pageSize);
+
+      const cached = cache.get(cacheKey) as ValidatorsPage | undefined;
+      if (cached) {
+        logger.debug("StakingService: validator page cache hit", { page, pageSize });
+        return {
+          ...cached,
+          data: filterByStatus(cached.data, params.status),
+        };
+      }
+
+      logger.debug("StakingService: validator page cache miss — fetching from RPC", {
+        page,
+        pageSize,
+      });
+      const [{ validators: bnbValidators, total }, contractValidators] = await Promise.all([
+        bnbRpcClient.getValidators({ page, pageSize }),
+        stakingRpcClient.getCreditContractValidators(),
+      ]);
+
+      const data = mapValidators(bnbValidators, contractValidators, logger);
+      const result: ValidatorsPage = {
+        data,
+        pagination: {
+          page,
+          pageSize,
+          total,
+          totalPages: Math.ceil(total / pageSize),
+          hasNextPage: page * pageSize < total,
+        },
+      };
+
+      cache.set(cacheKey, result);
+      logger.debug("StakingService: validator page cached", { page, pageSize, total });
+      return {
+        ...result,
+        data: filterByStatus(data, params.status),
+      };
     },
 
     async getDelegations(address: string): Promise<Delegations> {

--- a/packages/bsc/src/smartchain/services/staking-service.ts
+++ b/packages/bsc/src/smartchain/services/staking-service.ts
@@ -70,14 +70,15 @@ function mapValidators(
 }
 
 export function createStakingService(
-  cache: CacheContract<string, unknown>,
+  allValidatorsCache: CacheContract<string, Validator[]>,
+  pageCache: CacheContract<string, ValidatorsPage>,
   stakingRpcClient: StakingRpcClientContract,
   bnbRpcClient: BNBRpcClientContract,
   logger: Logger = new NoopLogger()
 ): StakingServiceContract {
   // BSC has ~50–60 validators — fetching all in one shot is intentional and cheap.
   async function fetchAllValidators(): Promise<Validator[]> {
-    const cached = cache.get(VALIDATOR_ALL_CACHE_KEY) as Validator[] | undefined;
+    const cached = allValidatorsCache.get(VALIDATOR_ALL_CACHE_KEY);
     if (cached) {
       logger.debug("StakingService: all-validators cache hit", { count: cached.length });
       return cached;
@@ -90,7 +91,7 @@ export function createStakingService(
     ]);
 
     const validators = mapValidators(bnbValidators, contractValidators, logger);
-    cache.set(VALIDATOR_ALL_CACHE_KEY, validators);
+    allValidatorsCache.set(VALIDATOR_ALL_CACHE_KEY, validators);
     logger.debug("StakingService: all-validators cached", { count: validators.length });
     return validators;
   }
@@ -185,7 +186,7 @@ export function createStakingService(
 
       const cacheKey = validatorPageCacheKey(page, pageSize);
 
-      const cached = cache.get(cacheKey) as ValidatorsPage | undefined;
+      const cached = pageCache.get(cacheKey);
       if (cached) {
         logger.debug("StakingService: validator page cache hit", { page, pageSize });
         return {
@@ -215,7 +216,7 @@ export function createStakingService(
         },
       };
 
-      cache.set(cacheKey, result);
+      pageCache.set(cacheKey, result);
       logger.debug("StakingService: validator page cached", { page, pageSize, total });
       return {
         ...result,

--- a/packages/bsc/src/smartchain/services/staking-service.ts
+++ b/packages/bsc/src/smartchain/services/staking-service.ts
@@ -43,18 +43,18 @@ function mapValidators(
   contractValidators: Map<Address, Address>,
   logger: Logger
 ): Validator[] {
-  return bnbValidators
-    .map((bnbValidator) => {
-      const operatorAddress = parseEvmAddress(bnbValidator.operatorAddress);
-      const creditAddress = contractValidators.get(operatorAddress);
-      if (!creditAddress) {
-        logger.warn("StakingService: validator has no credit address — skipping", {
-          moniker: bnbValidator.moniker,
-          operatorAddress,
-        });
-        return undefined;
-      }
-      return {
+  return bnbValidators.flatMap((bnbValidator) => {
+    const operatorAddress = parseEvmAddress(bnbValidator.operatorAddress);
+    const creditAddress = contractValidators.get(operatorAddress);
+    if (!creditAddress) {
+      logger.warn("StakingService: validator has no credit address — skipping", {
+        moniker: bnbValidator.moniker,
+        operatorAddress,
+      });
+      return [];
+    }
+    return [
+      {
         id: operatorAddress,
         status: getValidatorStatus(bnbValidator),
         name: bnbValidator.moniker,
@@ -64,9 +64,9 @@ function mapValidators(
         delegators: bnbValidator.delegatorCount,
         operatorAddress,
         creditAddress: parseEvmAddress(creditAddress),
-      };
-    })
-    .filter((v): v is NonNullable<typeof v> => v !== undefined);
+      },
+    ];
+  });
 }
 
 export function createStakingService(
@@ -103,20 +103,20 @@ export function createStakingService(
     const creditContracts = validators.map((v) => parseEvmAddress(v.creditAddress));
     const pooledBNBData = await stakingRpcClient.getPooledBNBData(creditContracts, address);
 
-    return pooledBNBData
-      .map((data, index) => {
-        const stakedAmount = processSingleMulticallResult(data);
-        if (stakedAmount === undefined) return undefined;
-        return {
+    return pooledBNBData.flatMap((data, index) => {
+      const stakedAmount = processSingleMulticallResult(data);
+      if (stakedAmount === undefined) return [];
+      return [
+        {
           id: `delegation_active_${index}`,
           validator: validators[index],
           amount: stakedAmount,
           status: "Active" as const,
           delegationIndex: -1n,
           pendingUntil: 0,
-        };
-      })
-      .filter((item) => item !== undefined);
+        },
+      ];
+    });
   }
 
   async function getUnbondDelegations(
@@ -156,19 +156,21 @@ export function createStakingService(
     );
 
     const delegationsPerValidator = await Promise.all(
-      pendingUnbond.map(async (result, index) => {
+      pendingUnbond.flatMap((result, index) => {
         const pendingCountRaw = processSingleMulticallResult(result);
-        if (pendingCountRaw === undefined) return undefined;
-        return getUnbondDelegations(
-          parseEvmAddress(validators[index].creditAddress),
-          address,
-          Number(pendingCountRaw),
-          validators[index]
-        );
+        if (pendingCountRaw === undefined) return [];
+        return [
+          getUnbondDelegations(
+            parseEvmAddress(validators[index].creditAddress),
+            address,
+            Number(pendingCountRaw),
+            validators[index]
+          ),
+        ];
       })
     );
 
-    return delegationsPerValidator.filter((d): d is Delegation[] => d !== undefined).flat();
+    return delegationsPerValidator.flat();
   }
 
   return {

--- a/packages/bsc/tests/services/balance-service.test.ts
+++ b/packages/bsc/tests/services/balance-service.test.ts
@@ -19,7 +19,10 @@ const mockStakingSummary = {
 
 function makeStakingService(delegations: any[]) {
   return {
-    getValidators: async () => [],
+    getValidators: async () => ({
+      data: [],
+      pagination: { page: 1, pageSize: 20, total: 0, totalPages: 0, hasNextPage: false },
+    }),
     getDelegations: async () => ({
       delegations,
       stakingSummary: mockStakingSummary,

--- a/packages/bsc/tests/services/staking-service.test.ts
+++ b/packages/bsc/tests/services/staking-service.test.ts
@@ -49,6 +49,7 @@ describe("StakingService", () => {
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
       );
@@ -62,6 +63,7 @@ describe("StakingService", () => {
       const bnbRpcClient = makeBNBRpcClient();
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
@@ -77,6 +79,7 @@ describe("StakingService", () => {
       const bnbRpcClient = makeBNBRpcClient();
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
@@ -104,6 +107,7 @@ describe("StakingService", () => {
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
       );
@@ -118,6 +122,7 @@ describe("StakingService", () => {
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
       );
@@ -130,6 +135,7 @@ describe("StakingService", () => {
     it("filters by a single status", async () => {
       const bnbRpcClient = makeBNBRpcClient({ status: "INACTIVE" });
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         bnbRpcClient as any
@@ -147,6 +153,7 @@ describe("StakingService", () => {
       const bnbRpcClient = makeBNBRpcClient({ status: "INACTIVE" });
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         makeStakingRpcClient() as any,
         bnbRpcClient as any
       );
@@ -157,6 +164,7 @@ describe("StakingService", () => {
 
     it("returns all validators when no params are provided", async () => {
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         makeBNBRpcClient() as any
@@ -169,6 +177,7 @@ describe("StakingService", () => {
     it("passes page and pageSize to the RPC client", async () => {
       const bnbRpcClient = makeBNBRpcClient();
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         bnbRpcClient as any
@@ -183,6 +192,7 @@ describe("StakingService", () => {
       const bnbRpcClient = makeBNBRpcClient();
       // Mock returns total: 3 for our 3-validator fixture
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         bnbRpcClient as any
@@ -200,6 +210,7 @@ describe("StakingService", () => {
     it("throws ValidationError for page 0", async () => {
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         makeStakingRpcClient() as any,
         makeBNBRpcClient() as any
       );
@@ -214,6 +225,7 @@ describe("StakingService", () => {
     it("throws ValidationError for negative page", async () => {
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         makeStakingRpcClient() as any,
         makeBNBRpcClient() as any
       );
@@ -227,6 +239,7 @@ describe("StakingService", () => {
 
     it("throws ValidationError for pageSize 0", async () => {
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         makeBNBRpcClient() as any
@@ -250,6 +263,7 @@ describe("StakingService", () => {
       ]);
       const stakingRpcClient = makeStakingRpcClient(partialMap as any);
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
@@ -275,6 +289,7 @@ describe("StakingService", () => {
         VALIDATORS.map(() => ({ status: "success", result: 0n }))
       );
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
@@ -306,6 +321,7 @@ describe("StakingService", () => {
       });
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
       );
@@ -335,6 +351,7 @@ describe("StakingService", () => {
       });
       const service = createStakingService(
         createInMemoryCache(),
+        createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any
       );
@@ -351,6 +368,7 @@ describe("StakingService", () => {
       const bnbRpcClient = makeBNBRpcClient();
       const stakingRpcClient = makeStakingRpcClient();
       const service = createStakingService(
+        createInMemoryCache(),
         createInMemoryCache(),
         stakingRpcClient as any,
         bnbRpcClient as any

--- a/packages/bsc/tests/services/staking-service.test.ts
+++ b/packages/bsc/tests/services/staking-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { getAddress } from "viem";
 import { createStakingService } from "../../src/smartchain/services/staking-service";
-import { createInMemoryCache } from "@guardian-sdk/sdk";
+import { createInMemoryCache, ValidationError } from "@guardian-sdk/sdk";
 import validatorsFixture from "../fixtures/bnb_validators.json";
 import summaryFixture from "../fixtures/bnb_staking_summary.json";
 import creditContractsFixture from "../fixtures/staking_credit_contracts.json";
@@ -24,7 +24,7 @@ function makeBNBRpcClient(
     : validators;
 
   return {
-    getValidators: vi.fn().mockResolvedValue(mapped),
+    getValidators: vi.fn().mockResolvedValue({ validators: mapped, total: mapped.length }),
     getStakingSummary: vi.fn().mockResolvedValue(SUMMARY),
   };
 }
@@ -82,7 +82,7 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const validators = await service.getValidators();
+      const { data: validators, pagination } = await service.getValidators();
 
       expect(validators).toHaveLength(3);
       expect(validators[0].name).toBe("TWStaking");
@@ -94,6 +94,9 @@ describe("StakingService", () => {
         getAddress("0xc437593d9c296bf9a5002522a86dad8a4d4af808")
       );
       expect(validators[0].apy).toBeCloseTo(VALIDATORS[0].apy! * 100, 5);
+      expect(pagination.total).toBe(3);
+      expect(pagination.page).toBe(1);
+      expect(pagination.pageSize).toBe(100);
     });
 
     it('maps INACTIVE status to "Inactive"', async () => {
@@ -105,7 +108,7 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const validators = await service.getValidators();
+      const { data: validators } = await service.getValidators();
 
       validators.forEach((v) => expect(v.status).toBe("Inactive"));
     });
@@ -119,7 +122,7 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const validators = await service.getValidators();
+      const { data: validators } = await service.getValidators();
 
       validators.forEach((v) => expect(v.status).toBe("Jailed"));
     });
@@ -132,10 +135,10 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const active = await service.getValidators("Active");
+      const { data: active } = await service.getValidators({ status: "Active" });
       expect(active).toHaveLength(0);
 
-      const inactive = await service.getValidators("Inactive");
+      const { data: inactive } = await service.getValidators({ status: "Inactive" });
       expect(inactive).toHaveLength(3);
       inactive.forEach((v) => expect(v.status).toBe("Inactive"));
     });
@@ -148,19 +151,92 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const result = await service.getValidators(["Active", "Inactive"]);
-      expect(result).toHaveLength(3);
+      const { data } = await service.getValidators({ status: ["Active", "Inactive"] });
+      expect(data).toHaveLength(3);
     });
 
-    it("returns all validators when no status filter is provided", async () => {
+    it("returns all validators when no params are provided", async () => {
       const service = createStakingService(
         createInMemoryCache(),
         makeStakingRpcClient() as any,
         makeBNBRpcClient() as any
       );
 
-      const all = await service.getValidators();
-      expect(all).toHaveLength(3);
+      const { data } = await service.getValidators();
+      expect(data).toHaveLength(3);
+    });
+
+    it("passes page and pageSize to the RPC client", async () => {
+      const bnbRpcClient = makeBNBRpcClient();
+      const service = createStakingService(
+        createInMemoryCache(),
+        makeStakingRpcClient() as any,
+        bnbRpcClient as any
+      );
+
+      await service.getValidators({ page: 2, pageSize: 10 });
+
+      expect(bnbRpcClient.getValidators).toHaveBeenCalledWith({ page: 2, pageSize: 10 });
+    });
+
+    it("returns correct pagination metadata", async () => {
+      const bnbRpcClient = makeBNBRpcClient();
+      // Mock returns total: 3 for our 3-validator fixture
+      const service = createStakingService(
+        createInMemoryCache(),
+        makeStakingRpcClient() as any,
+        bnbRpcClient as any
+      );
+
+      const { pagination } = await service.getValidators({ page: 1, pageSize: 2 });
+
+      expect(pagination.page).toBe(1);
+      expect(pagination.pageSize).toBe(2);
+      expect(pagination.total).toBe(3);
+      expect(pagination.totalPages).toBe(2);
+      expect(pagination.hasNextPage).toBe(true);
+    });
+
+    it("throws ValidationError for page 0", async () => {
+      const service = createStakingService(
+        createInMemoryCache(),
+        makeStakingRpcClient() as any,
+        makeBNBRpcClient() as any
+      );
+
+      await expect(service.getValidators({ page: 0 })).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(ValidationError);
+        expect((err as ValidationError).code).toBe("INVALID_PAGE");
+        return true;
+      });
+    });
+
+    it("throws ValidationError for negative page", async () => {
+      const service = createStakingService(
+        createInMemoryCache(),
+        makeStakingRpcClient() as any,
+        makeBNBRpcClient() as any
+      );
+
+      await expect(service.getValidators({ page: -1 })).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(ValidationError);
+        expect((err as ValidationError).code).toBe("INVALID_PAGE");
+        return true;
+      });
+    });
+
+    it("throws ValidationError for pageSize 0", async () => {
+      const service = createStakingService(
+        createInMemoryCache(),
+        makeStakingRpcClient() as any,
+        makeBNBRpcClient() as any
+      );
+
+      await expect(service.getValidators({ pageSize: 0 })).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(ValidationError);
+        expect((err as ValidationError).code).toBe("INVALID_PAGE_SIZE");
+        return true;
+      });
     });
 
     it("skips validators with no matching credit address", async () => {
@@ -179,7 +255,7 @@ describe("StakingService", () => {
         bnbRpcClient as any
       );
 
-      const validators = await service.getValidators();
+      const { data: validators } = await service.getValidators();
 
       expect(validators).toHaveLength(1);
       expect(validators[0].name).toBe("TWStaking");

--- a/packages/bsc/tests/services/staking-service.test.ts
+++ b/packages/bsc/tests/services/staking-service.test.ts
@@ -132,36 +132,6 @@ describe("StakingService", () => {
       validators.forEach((v) => expect(v.status).toBe("Jailed"));
     });
 
-    it("filters by a single status", async () => {
-      const bnbRpcClient = makeBNBRpcClient({ status: "INACTIVE" });
-      const service = createStakingService(
-        createInMemoryCache(),
-        createInMemoryCache(),
-        makeStakingRpcClient() as any,
-        bnbRpcClient as any
-      );
-
-      const { data: active } = await service.getValidators({ status: "Active" });
-      expect(active).toHaveLength(0);
-
-      const { data: inactive } = await service.getValidators({ status: "Inactive" });
-      expect(inactive).toHaveLength(3);
-      inactive.forEach((v) => expect(v.status).toBe("Inactive"));
-    });
-
-    it("filters by multiple statuses", async () => {
-      const bnbRpcClient = makeBNBRpcClient({ status: "INACTIVE" });
-      const service = createStakingService(
-        createInMemoryCache(),
-        createInMemoryCache(),
-        makeStakingRpcClient() as any,
-        bnbRpcClient as any
-      );
-
-      const { data } = await service.getValidators({ status: ["Active", "Inactive"] });
-      expect(data).toHaveLength(3);
-    });
-
     it("returns all validators when no params are provided", async () => {
       const service = createStakingService(
         createInMemoryCache(),

--- a/packages/sdk/src/cache/in-memory-cache.ts
+++ b/packages/sdk/src/cache/in-memory-cache.ts
@@ -55,7 +55,7 @@ export function createInMemoryCache<K, V>(defaultTtlMs = 180000): CacheContract<
 
     has(key) {
       const entry = store.get(key);
-      return !!entry && Date.now() < entry.expirationInMillis;
+      return entry !== undefined && Date.now() < entry.expirationInMillis;
     },
 
     clear() {

--- a/packages/sdk/src/entity/errors.ts
+++ b/packages/sdk/src/entity/errors.ts
@@ -22,7 +22,9 @@ export type ValidationErrorCode =
   | "INVALID_AMOUNT"
   | "INVALID_NONCE"
   | "INVALID_FEE"
-  | "INVALID_PRIVATE_KEY";
+  | "INVALID_PRIVATE_KEY"
+  | "INVALID_PAGE"
+  | "INVALID_PAGE_SIZE";
 
 export type ConfigErrorCode = "UNSUPPORTED_CHAIN" | "INVALID_RPC_URL";
 

--- a/packages/sdk/src/entity/staking-types.ts
+++ b/packages/sdk/src/entity/staking-types.ts
@@ -1,3 +1,22 @@
+export interface GetValidatorsParams {
+  status?: ValidatorStatus | ValidatorStatus[];
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ValidatorsPagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+}
+
+export interface ValidatorsPage {
+  data: Validator[];
+  pagination: ValidatorsPagination;
+}
+
 export interface Validator {
   id: string;
   status: ValidatorStatus;

--- a/packages/sdk/src/entity/staking-types.ts
+++ b/packages/sdk/src/entity/staking-types.ts
@@ -1,5 +1,4 @@
 export interface GetValidatorsParams {
-  status?: ValidatorStatus | ValidatorStatus[];
   page?: number;
   pageSize?: number;
 }

--- a/packages/sdk/src/entity/staking-validation.ts
+++ b/packages/sdk/src/entity/staking-validation.ts
@@ -1,0 +1,9 @@
+import { ValidationError } from "./errors";
+import type { GetValidatorsParams } from "./staking-types";
+
+export function validatePageParams(params: GetValidatorsParams): void {
+  if (params.page !== undefined && (!Number.isInteger(params.page) || params.page < 1))
+    throw new ValidationError("INVALID_PAGE", "page must be an integer of 1 or greater");
+  if (params.pageSize !== undefined && (!Number.isInteger(params.pageSize) || params.pageSize < 1))
+    throw new ValidationError("INVALID_PAGE_SIZE", "pageSize must be an integer of 1 or greater");
+}

--- a/packages/sdk/src/sdk/index.ts
+++ b/packages/sdk/src/sdk/index.ts
@@ -9,7 +9,7 @@ import type {
   PrehashResult,
   SigningWithPrivateKey,
 } from "../entity/sign-types";
-import type { Delegations, Validator, ValidatorStatus } from "../entity/staking-types";
+import type { Delegations, GetValidatorsParams, ValidatorsPage } from "../entity/staking-types";
 import type { Transaction } from "../entity/transaction-types";
 
 /**
@@ -35,11 +35,8 @@ export class GuardianSDK {
     this.services = new Map(services.map((s) => [s.getChainInfo().id, s]));
   }
 
-  getValidators(
-    chain: GuardianChain,
-    status?: ValidatorStatus | ValidatorStatus[]
-  ): Promise<Validator[]> {
-    return this.getService(chain).getValidators(status);
+  getValidators(chain: GuardianChain, params?: GetValidatorsParams): Promise<ValidatorsPage> {
+    return this.getService(chain).getValidators(params);
   }
 
   getDelegations(chain: GuardianChain, address: string): Promise<Delegations> {

--- a/packages/sdk/src/service/guardian-service-contract.ts
+++ b/packages/sdk/src/service/guardian-service-contract.ts
@@ -8,10 +8,10 @@ import type {
   PrehashResult,
   SigningWithPrivateKey,
 } from "../entity/sign-types";
-import type { Delegations, Validator, ValidatorStatus } from "../entity/staking-types";
+import type { Delegations, GetValidatorsParams, ValidatorsPage } from "../entity/staking-types";
 /** Chain-agnostic contract for the Guardian Service facade. Implemented by each chain package. */
 export interface GuardianServiceContract {
-  getValidators(status?: ValidatorStatus | ValidatorStatus[]): Promise<Validator[]>;
+  getValidators(params?: GetValidatorsParams): Promise<ValidatorsPage>;
   getDelegations(address: string): Promise<Delegations>;
   getBalances(address: string): Promise<Balance[]>;
   getNonce(address: string): Promise<number>;

--- a/packages/sdk/src/service/index.ts
+++ b/packages/sdk/src/service/index.ts
@@ -24,6 +24,9 @@ export type {
   Delegation,
   DelegationStatus,
   StakingSummary,
+  GetValidatorsParams,
+  ValidatorsPagination,
+  ValidatorsPage,
 } from "../entity/staking-types";
 
 export {

--- a/packages/sdk/src/service/index.ts
+++ b/packages/sdk/src/service/index.ts
@@ -17,6 +17,7 @@ export type {
   TransactionType,
 } from "../entity/transaction-types";
 export { filterByStatus } from "../entity/staking-types";
+export { validatePageParams } from "../entity/staking-validation";
 export type {
   Validator,
   ValidatorStatus,

--- a/packages/sdk/src/service/staking-service-contract.ts
+++ b/packages/sdk/src/service/staking-service-contract.ts
@@ -1,12 +1,13 @@
-import type { Delegations, Validator, ValidatorStatus } from "../entity/staking-types";
+import type { Delegations, GetValidatorsParams, ValidatorsPage } from "../entity/staking-types";
 
 /** Contract for a service responsible for staking operations. */
 export interface StakingServiceContract {
   /**
-   * Returns validators on the network.
-   * Pass a status (or array of statuses) to filter; omit to return all.
+   * Returns a paginated page of validators.
+   * Use `params.page` / `params.pageSize` for pagination (1-based page, default 20 per page).
+   * Use `params.status` to filter by validator status.
    */
-  getValidators(status?: ValidatorStatus | ValidatorStatus[]): Promise<Validator[]>;
+  getValidators(params?: GetValidatorsParams): Promise<ValidatorsPage>;
 
   /**
    * Returns all delegations for the given address plus a protocol-level summary.

--- a/packages/sdk/src/testing/mock-service.ts
+++ b/packages/sdk/src/testing/mock-service.ts
@@ -1,6 +1,12 @@
 import type { GuardianChain } from "../chain";
 import type { GuardianServiceContract } from "../service/guardian-service-contract";
-import type { Validator, Delegation, Delegations, StakingSummary } from "../entity/staking-types";
+import type {
+  Validator,
+  Delegation,
+  Delegations,
+  StakingSummary,
+  ValidatorsPage,
+} from "../entity/staking-types";
 import type { Balance, BalanceType } from "../entity/balance-types";
 import type { Fee } from "../entity/fee-types";
 import type {
@@ -48,7 +54,11 @@ export function createMockService(
 ): GuardianServiceContract {
   return {
     getChainInfo: () => chain,
-    getValidators: () => Promise.resolve([]),
+    getValidators: () =>
+      Promise.resolve<ValidatorsPage>({
+        data: [],
+        pagination: { page: 1, pageSize: 20, total: 0, totalPages: 0, hasNextPage: false },
+      }),
     getDelegations: () => Promise.resolve(mockDelegations()),
     getBalances: () => Promise.resolve([]),
     getNonce: () => Promise.resolve(0),


### PR DESCRIPTION
## Summary
  
  https://github.com/JaimeToca/guardian-stake-sdk/issues/42

  - `getValidators` now accepts `{ page, pageSize }` and returns `ValidatorsPage` instead of `Validator[]`. Pagination flows to the
  BNB Chain API as `limit`/`offset` — no client-side slicing. There is no `status` param: callers filter by status client-side with
  `filterByStatus(page.data, status)` from the SDK (adding it to params would make pagination metadata unreliable —
  `total`/`totalPages`/`hasNextPage` would describe the unfiltered set while `data` was filtered).
  - Validator `id` is now the stable `operatorAddress` instead of an index-based string that changed across pages.
  - New types and utilities exported from `@guardian-sdk/sdk`: `GetValidatorsParams`, `ValidatorsPage`, `ValidatorsPagination`,
  `validatePageParams`, `filterByStatus`.
  - Input validation guards against `page < 1` and `pageSize < 1`, throwing typed `ValidationError` with codes `INVALID_PAGE` /
  `INVALID_PAGE_SIZE`. `validatePageParams` lives in its own file (`entity/staking-validation.ts`) following the
  `config-validation.ts` pattern.
  - `createStakingService` now takes two typed caches (`CacheContract<string, Validator[]>` and `CacheContract<string,
  ValidatorsPage>`) instead of a single `unknown` cache — no type casts at call sites.
  - `getDelegations` is unaffected — it uses a separate internal `fetchAllValidators` path that fetches all validators in one shot
  (intentional: BSC has ~50–60).
  - Internal: `map` + `filter(undefined)` patterns replaced with `flatMap` throughout `staking-service.ts`.
  - All chain implementations of `GuardianServiceContract` must adopt the new `getValidators` signature.

  ## Test plan

  - [x] `pnpm run format:check` passes
  - [x] `pnpm run lint` passes
  - [x] `pnpm run typecheck` passes (includes `examples/tsconfig.json`)
  - [x] `pnpm run test` passes (62 tests, includes new cases for pagination metadata, RPC call args, `INVALID_PAGE`,
  `INVALID_PAGE_SIZE`)
  - [x] Sample typechecks: `tsc --noEmit -p examples/tsconfig.json`

* **New Features**
  * getValidators() now supports pagination (page, pageSize) and returns validators with pagination metadata (total, page, totalPages, hasNextPage)
  * Status filtering can be applied via params alongside pagination

* **Documentation**
  * Examples updated to show page navigation, per-page caching guidance, and pagination usage

* **Tests**
  * Test fixtures and suites updated to use the new paginated return shape and validate pagination behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaimeToca/guardian-stake-sdk/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->